### PR TITLE
TradingView strategy comment

### DIFF
--- a/core/mod.core.js
+++ b/core/mod.core.js
@@ -224,7 +224,7 @@ module.exports = class frostybot_core_module extends frostybot_module {
             if (this.load_module(module)) {
             //if (typeof(this[module] == 'function')) {
                 this.output.notice('loaded_module', module)    
-                var method = this.utils.is_array(method.split(':')) ? method.split(':')[0] : method;
+                var method = this.utils.is_array(method.split(':')) ? String.prototype.toLowerCase(method.split(':')[0]) : String.prototype.toLowerCase(method);
                 if (this.method_exists(module, method)) {
                     var start = (new Date).getTime();
                     global.frostybot['command'] = {


### PR DESCRIPTION
When you use the strategy comment, on TradingView, it start with an uppercase, which lead to an unknown command.
Just lower it and it's all good for any cases