### PR TITLE
Stop Limit and Market Orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Frostybot can be deployed in 3 supported ways. Depending on your personal deploy
 
 To install Frostybot-JS on Ubuntu 20.04 LTS, run these commands:
 ```
-curl -skL https://tinyurl.com/frostybot-js -o /tmp/install.sh 
+curl -skL https://tinyurl.com/frostybot-js-ichibot200 -o /tmp/install.sh 
 sudo chmod +x /tmp/install.sh
 sudo /tmp/install.sh
 ````

--- a/core/mod.trade.js
+++ b/core/mod.trade.js
@@ -792,7 +792,7 @@ module.exports = class frostybot_trade_module extends frostybot_module {
 
         // Extract params
         params = this.mod.utils.lower_props(params);
-        var [stub, symbol, side, price, post, ioc, reduce, tag] = this.mod.utils.extract_props(params, ['stub', 'symbol', 'side', 'price', 'post', 'ioc', 'reduce', 'tag']);
+        var [stub, symbol, side, price, stopprice, post, ioc, reduce, tag] = this.mod.utils.extract_props(params, ['stub', 'symbol', 'side', 'price', 'stopprice', 'post', 'ioc', 'reduce', 'tag']);
         
         // Get parameters from the normalizer
         var param_map = await this.setting(stub, 'param_map');
@@ -824,10 +824,11 @@ module.exports = class frostybot_trade_module extends frostybot_module {
         var param_map = await this.setting(stub, 'param_map');
         var order_params = {
             symbol  :   symbol.toUpperCase(),
-            type    :   param_map[(price == undefined ? 'market' : 'limit')],
+            type    :   param_map[((price != undefined && stopprice != undefined) ? 'stop' : (price == undefined ? 'stop_market' : (stopprice == undefined ? 'limit' : 'market')))],
             side    :   side,
             amount  :   amount,
             price   :   (price != undefined ? price : null),
+            stopPrice : (stopprice != undefined ? stopprice : null)
             params  :   {}
         }
 

--- a/exchanges/exchange.binance.futures.js
+++ b/exchanges/exchange.binance.futures.js
@@ -21,6 +21,8 @@ module.exports = class frostybot_exchange_binance_futures extends frostybot_exch
         this.param_map = {                           // Order parameter mappings
             limit              : 'LIMIT',
             market             : 'MARKET',
+            stop               : 'STOP',
+            stop_market        : 'STOP_MARKET',
             stoploss_limit     : 'STOP',
             stoploss_market    : 'STOP_MARKET',
             takeprofit_limit   : 'TAKE_PROFIT', 

--- a/scripts/install
+++ b/scripts/install
@@ -14,7 +14,7 @@ sudo -E apt-get -qy -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--f
 
 echo "Cloning Frostybot Github repository..."
 sudo mkdir -p /usr/local && cd /usr/local/
-sudo git clone https://github.com/CryptoMF/frostybot-js.git frostybot-js >> /tmp/install.log 2>&1
+sudo git clone https://github.com/Ichibot200/frostybot-js.git frostybot-js >> /tmp/install.log 2>&1
 
 echo "Setting permissions..."
 cd /usr/local/frostybot-js


### PR DESCRIPTION
Pardon me if I am mistaken, but currently, FrostyBot Allows for Limit or Market orders only. But there should be options for Stop-Limit and Stop-Market orders as well.

This change should allow posting Long or Short orders in Binance Futures as Stop-Limit or Stop-Market Orders.

I have made some initial modifications that I see would make it possible.

The command syntax for new order would be like this:
__trade:stub:long price=10.1 stopprice=10 base=100 symbol=*/USDT__ --- for Long Stop-Limit Order
__trade:stub:short price=9.9 stopprice=10 base=100 symbol=*/USDT__ --- for Short Stop-Limit Order
__trade:stub:long stopprice=10 base=100 symbol=*/USDT__ --- for Long Stop-Limit Order
__trade:stub:short stopprice=10 base=100 symbol=*/USDT__  --- for Short Stop-Market Order

Perhaps there have to be more changes in the core script library, that I do not know yet.
Let's make the necessary adjustments and merge this PR for improved FrostyBot functionality.

From my commits README and install script can be omitted.
